### PR TITLE
Get Play app secret from the AWS parameter store

### DIFF
--- a/src/main/scala/MyApplicationLoader.scala
+++ b/src/main/scala/MyApplicationLoader.scala
@@ -43,8 +43,8 @@ class MyComponents(context: Context)
   // I guess it could be nice if a given config knew whether it was
   // request-environment-dependent or app-mode-dependent
   override val configuration: Configuration = playConfigUpdater
-    .update[DBConfig](requestEnvironments)
-    .update[AppConfig](environment.mode)
+    .merge[DBConfig](requestEnvironments)
+    .merge[AppConfig](environment.mode)
     .configuration
 
   val databaseProvider = new DatabaseProvider(dbApi)

--- a/src/main/scala/MyApplicationLoader.scala
+++ b/src/main/scala/MyApplicationLoader.scala
@@ -48,7 +48,7 @@ class MyComponents(context: Context)
   val withDBAndAppConfig = PlayConfigEncoder.updateForAppMode[AppConfig](
     configLoader,
     withDBConfig,
-    application.mode
+    environment.mode
   )
 
   override val configuration: Configuration = withDBAndAppConfig

--- a/src/main/scala/MyApplicationLoader.scala
+++ b/src/main/scala/MyApplicationLoader.scala
@@ -9,7 +9,7 @@ import aws.AWSClientBuilder
 import backend.{PaypalBackend, StripeBackend}
 import _root_.controllers.StripeController
 import _root_.controllers.PaypalController
-import conf.{AppConfig, ConfigLoader, DBConfig, PlayConfigEncoder}
+import conf.{AppConfig, DBConfig, PlayConfigUpdater, ConfigLoader}
 import model.{DefaultThreadPool, DefaultThreadPoolProvider, RequestEnvironments}
 import services.DatabaseProvider
 
@@ -38,20 +38,14 @@ class MyComponents(context: Context)
   val ssm: AWSSimpleSystemsManagement = AWSClientBuilder.buildAWSSimpleSystemsManagementClient()
   val configLoader: ConfigLoader = new ConfigLoader(ssm)
 
-  // TODO: nicer way of merging in multiple configs.
-  val withDBConfig = PlayConfigEncoder.updateForRequestEnvironments[DBConfig](
-    configLoader,
-    super.configuration,
-    requestEnvironments,
-  )
+  val playConfigUpdater = new PlayConfigUpdater(configLoader, super.configuration)
 
-  val withDBAndAppConfig = PlayConfigEncoder.updateForAppMode[AppConfig](
-    configLoader,
-    withDBConfig,
-    environment.mode
-  )
-
-  override val configuration: Configuration = withDBAndAppConfig
+  // I guess it could be nice if a given config knew whether it was
+  // request-environment-dependent or app-mode-dependent
+  override val configuration: Configuration = playConfigUpdater
+    .update[DBConfig](requestEnvironments)
+    .update[AppConfig](environment.mode)
+    .configuration
 
   val databaseProvider = new DatabaseProvider(dbApi)
 

--- a/src/main/scala/backend/PaypalBackend.scala
+++ b/src/main/scala/backend/PaypalBackend.scala
@@ -27,8 +27,12 @@ object PaypalBackend {
     extends EnvironmentBasedBuilder[PaypalBackend] {
 
     override def build(env: Environment): InitializationResult[PaypalBackend] = (
-      configLoader.loadConfig[PaypalConfig](env).andThen(PaypalService.fromPaypalConfig): InitializationResult[PaypalService],
-      databaseProvider.loadDatabase(env).andThen(PostgresDatabaseService.fromDatabase): InitializationResult[DatabaseService]
+      configLoader
+        .configForEnvironment[PaypalConfig](env)
+        .andThen(PaypalService.fromPaypalConfig): InitializationResult[PaypalService],
+      databaseProvider
+        .loadDatabase(env)
+        .andThen(PostgresDatabaseService.fromDatabase): InitializationResult[DatabaseService]
     ).mapN(PaypalBackend.apply)
   }
 

--- a/src/main/scala/backend/StripeBackend.scala
+++ b/src/main/scala/backend/StripeBackend.scala
@@ -41,8 +41,12 @@ object StripeBackend {
     extends EnvironmentBasedBuilder[StripeBackend] {
 
     override def build(env: Environment): InitializationResult[StripeBackend] = (
-      configLoader.loadConfig[StripeConfig](env).andThen(StripeService.fromStripeConfig): InitializationResult[StripeService],
-      databaseProvider.loadDatabase(env).andThen(PostgresDatabaseService.fromDatabase): InitializationResult[DatabaseService]
+      configLoader
+        .configForEnvironment[StripeConfig](env)
+        .andThen(StripeService.fromStripeConfig): InitializationResult[StripeService],
+      databaseProvider
+        .loadDatabase(env)
+        .andThen(PostgresDatabaseService.fromDatabase): InitializationResult[DatabaseService]
     ).mapN(StripeBackend.apply)
   }
 }

--- a/src/main/scala/conf/AppConfig.scala
+++ b/src/main/scala/conf/AppConfig.scala
@@ -1,0 +1,41 @@
+package conf
+
+import cats.data.Validated
+import com.amazonaws.services.simplesystemsmanagement.model.GetParametersByPathRequest
+import conf.ConfigLoader._
+import model.InitializationError
+import play.api.{Configuration, Mode}
+
+case class AppConfig(secret: String)
+
+
+object AppConfig {
+  implicit val appConfigParameterStoreLoadable: ParameterStoreLoadableByPlayAppMode[AppConfig] = new ParameterStoreLoadableByPlayAppMode[AppConfig] {
+
+    override def parametersByPathRequest(mode: Mode): GetParametersByPathRequest =
+      new GetParametersByPathRequest()
+        .withPath(s"/payment-api/app-config/${mode.asJava.toString.toLowerCase}/")
+        .withRecursive(false)
+        .withWithDecryption(true)
+
+    override def decode(mode: Mode, data: Map[String, String]): Validated[InitializationError, AppConfig] = {
+      val validator = new ParameterStoreValidator[AppConfig, Mode](mode, data); import validator._
+      validate("secret").map(AppConfig.apply)
+    }
+  }
+
+  implicit val appConfigCovertibleToPlayConfig: PlayConfigEncoder[AppConfig] = new PlayConfigEncoder[AppConfig] {
+    override def asPlayConfig(conf: AppConfig): Configuration = {
+      // I wonder if I can just do "play.http.secret.key"?
+      Configuration(
+        "play" -> Map(
+          "http" -> Map(
+            "secret" -> Map(
+              "key" -> conf.secret
+            )
+          )
+        )
+      )
+    }
+  }
+}

--- a/src/main/scala/conf/ConfigLoader.scala
+++ b/src/main/scala/conf/ConfigLoader.scala
@@ -72,12 +72,12 @@ object ConfigLoader {
   @typeclass trait ParameterStoreLoadableByEnvironment[A] extends ParameterStoreLoadable[Environment, A]
   @typeclass trait ParameterStoreLoadableByPlayAppMode[A] extends ParameterStoreLoadable[Mode, A]
 
-  private class Context[A] {
+  private class PartiallyAppliedContext[A] {
     def apply[EnvType: Show](env: EnvType)(implicit ct: ClassTag[A]): String =
       s"type: ${classTag[A].runtimeClass}, environment: ${env.show}"
   }
 
-  private def context[A]: Context[A] = new Context[A]
+  private def context[A]: PartiallyAppliedContext[A] = new PartiallyAppliedContext[A]
 
   // Utility class for implementing instances of the ParameterStoreLoadable typeclass.
   class ParameterStoreValidator[A : ClassTag, EnvType : Show](env: EnvType, data: Map[String, String]) {

--- a/src/main/scala/conf/ConfigLoader.scala
+++ b/src/main/scala/conf/ConfigLoader.scala
@@ -18,6 +18,7 @@ import play.api.Mode
 
 // Load config from AWS parameter store.
 class ConfigLoader(ssm: AWSSimpleSystemsManagement) {
+  import ConfigLoader._
 
   @tailrec private def executePathRequestImpl(request: GetParametersByPathRequest, data: Map[String, String]): Map[String, String] = {
     val result = ssm.getParametersByPath(request)
@@ -53,8 +54,8 @@ class ConfigLoader(ssm: AWSSimpleSystemsManagement) {
 }
 
 object ConfigLoader {
-  implicit val environmentShow = Show.show[Environment](e => s"${e.entryName} request environment")
-  implicit val playAppModeShow = Show.show[Mode](m => s"${m.asJava.toString} Play app mode")
+  implicit val environmentShow: Show[Environment] = Show.show[Environment](e => s"${e.entryName} request environment")
+  implicit val playAppModeShow: Show[Mode] = Show.show[Mode](m => s"${m.asJava.toString} Play app mode")
 
   trait ParameterStoreLoadable[EnvType, A] {
 

--- a/src/main/scala/conf/ConfigLoader.scala
+++ b/src/main/scala/conf/ConfigLoader.scala
@@ -1,8 +1,10 @@
 package conf
 
+import cats.Show
 import cats.data.Validated
 import cats.syntax.either._
 import cats.syntax.validated._
+import cats.syntax.show._
 import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagement
 import com.amazonaws.services.simplesystemsmanagement.model.GetParametersByPathRequest
 import simulacrum.typeclass
@@ -10,9 +12,9 @@ import simulacrum.typeclass
 import scala.annotation.tailrec
 import scala.collection.JavaConverters._
 import scala.reflect._
-
 import conf.ConfigLoader._
 import model.{Environment, InitializationError, InitializationResult}
+import play.api.Mode
 
 // Load config from AWS parameter store.
 class ConfigLoader(ssm: AWSSimpleSystemsManagement) {
@@ -28,48 +30,63 @@ class ConfigLoader(ssm: AWSSimpleSystemsManagement) {
     else executePathRequestImpl(request.withNextToken(result.getNextToken), updatedData)
   }
 
-  private def executePathRequest[A : ClassTag](env: Environment, request: GetParametersByPathRequest): Either[InitializationError, Map[String, String]] =
+  private def executePathRequest[A : ClassTag, EnvType : Show](env: EnvType, request: GetParametersByPathRequest): Either[InitializationError, Map[String, String]] =
     Either.catchNonFatal(executePathRequestImpl(request, Map.empty)).leftMap { err =>
       InitializationError(s"error executing the parameter store request (${context[A](env)})", err)
     }
 
-  def loadConfig[A : ParameterStoreLoadable : ClassTag](env: Environment): InitializationResult[A] = {
-    val request = ParameterStoreLoadable[A].parametersByPathRequest(env)
+  def configForEnvironment[A : ParameterStoreLoadableByEnvironment : ClassTag](env: Environment): InitializationResult[A] = {
+    val request = ParameterStoreLoadableByEnvironment[A].parametersByPathRequest(env)
     (for {
-      result <- executePathRequest[A](env, request)
-      config <- ParameterStoreLoadable[A].decode(env, result).toEither
+      result <- executePathRequest[A, Environment](env, request)
+      config <- ParameterStoreLoadableByEnvironment[A].decode(env, result).toEither
+    } yield config).toValidated
+  }
+
+  def configForPlayAppMode[A : ParameterStoreLoadableByPlayAppMode : ClassTag](mode: Mode): InitializationResult[A] = {
+    val request = ParameterStoreLoadableByPlayAppMode[A].parametersByPathRequest(mode)
+    (for {
+      result <- executePathRequest[A, Mode](mode, request)
+      config <- ParameterStoreLoadableByPlayAppMode[A].decode(mode, result).toEither
     } yield config).toValidated
   }
 }
 
 object ConfigLoader {
+  implicit val environmentShow = Show.show[Environment](e => s"${e.entryName} request environment")
+  implicit val playAppModeShow = Show.show[Mode](m => s"${m.asJava.toString} Play app mode")
 
-  // A class should implement this in order to be able be loaded from the parameter store.
-  @typeclass trait ParameterStoreLoadable[A] {
+  trait ParameterStoreLoadable[EnvType, A] {
 
     // The request to get all parameters required to build an instance of A for the given environment.
     // Parameters should be organised such that they can be obtained using a single path request.
-    def parametersByPathRequest(environment: Environment): GetParametersByPathRequest
+    def parametersByPathRequest(environment: EnvType): GetParametersByPathRequest
 
     // The config loader takes care of executing the request and deserializing it to a Map[String, String]
     // The typeclass instance should then be able to transform this to an instance of A.
-    def decode(environment: Environment, data: Map[String, String]): Validated[InitializationError, A]
+    def decode(environment: EnvType, data: Map[String, String]): Validated[InitializationError, A]
   }
 
-  // Used to add context to an initialization error
-  // TODO: consider making this a method on the InitializationError class
-  private def context[A : ClassTag](environment: Environment): String =
-    s"type: ${classTag[A].runtimeClass}, environment: ${environment.entryName}"
+  // A class should implement one of these in order to be loadable from the parameter store.
+  @typeclass trait ParameterStoreLoadableByEnvironment[A] extends ParameterStoreLoadable[Environment, A]
+  @typeclass trait ParameterStoreLoadableByPlayAppMode[A] extends ParameterStoreLoadable[Mode, A]
+
+  private class Context[A] {
+    def apply[EnvType: Show](env: EnvType)(implicit ct: ClassTag[A]): String =
+      s"type: ${classTag[A].runtimeClass}, environment: ${env.show}"
+  }
+
+  private def context[A]: Context[A] = new Context[A]
 
   // Utility class for implementing instances of the ParameterStoreLoadable typeclass.
-  class ParameterStoreValidator[A : ClassTag](environment: Environment, data: Map[String, String]) {
+  class ParameterStoreValidator[A : ClassTag, EnvType : Show](env: EnvType, data: Map[String, String]) {
 
     // If we need to make this method generic on the return type, we can pass an implicit ReaderT[Option, String, A],
     // to handle the parsing of a String to type A, but for now it's not required.
     def validate(key: String): InitializationResult[String] =
     // Need to specify the type of the fold explicitly
       data.get(key).fold[InitializationResult[String]](
-        InitializationError(s"the key: $key is missing from the parameter store (${context[A](environment)}").invalid
+        InitializationError(s"the key: $key is missing from the parameter store (${context[A](env)}").invalid
       )(_.valid)
 
     def validated[B](data: B): InitializationResult[B] = data.valid

--- a/src/main/scala/conf/DBConfig.scala
+++ b/src/main/scala/conf/DBConfig.scala
@@ -3,16 +3,17 @@ package conf
 import cats.data.Validated
 import cats.syntax.apply._
 import com.amazonaws.services.simplesystemsmanagement.model.GetParametersByPathRequest
-
 import conf.ConfigLoader._
 import model.{Environment, InitializationError}
+import play.api.Configuration
+
 
 // TODO: just use Play's DatabaseConfig case class instead?
 case class DBConfig(env: Environment, url: String, driver: String, username: String, password: String)
 
 object DBConfig {
 
-  implicit val dbConfigParameterStoreLoadable: ParameterStoreLoadable[DBConfig] = new ParameterStoreLoadable[DBConfig] {
+  implicit val dbConfigParameterStoreLoadable: ParameterStoreLoadableByEnvironment[DBConfig] = new ParameterStoreLoadableByEnvironment[DBConfig] {
 
     override def parametersByPathRequest(environment: Environment): GetParametersByPathRequest =
       new GetParametersByPathRequest()
@@ -21,8 +22,7 @@ object DBConfig {
         .withWithDecryption(true)
 
     override def decode(env: Environment, data: Map[String, String]): Validated[InitializationError, DBConfig] = {
-
-      val validator = new ParameterStoreValidator[DBConfig](env, data); import validator._
+      val validator = new ParameterStoreValidator[DBConfig, Environment](env, data); import validator._
       (
         validated(env),
         validate("url"),
@@ -32,4 +32,20 @@ object DBConfig {
       ).mapN(DBConfig.apply)
     }
   }
+
+  implicit val dbConfigCovertibleToPlayConfig: PlayConfigEncoder[DBConfig] = new PlayConfigEncoder[DBConfig] {
+    override def asPlayConfig(conf: DBConfig): Configuration = {
+      Configuration(
+        "db" -> Map(
+          conf.env.entryName -> Map(
+            "url" -> conf.url,
+            "driver" -> conf.driver,
+            "username" -> conf.username,
+            "password" -> conf.password
+          )
+        )
+      )
+    }
+  }
 }
+

--- a/src/main/scala/conf/PaypalConfig.scala
+++ b/src/main/scala/conf/PaypalConfig.scala
@@ -3,7 +3,7 @@ package conf
 import cats.data.Validated
 import cats.syntax.apply._
 import com.amazonaws.services.simplesystemsmanagement.model.GetParametersByPathRequest
-import conf.ConfigLoader.{ParameterStoreLoadable, ParameterStoreValidator}
+import conf.ConfigLoader.{ParameterStoreLoadableByEnvironment, ParameterStoreValidator, environmentShow}
 import model.paypal.PaypalMode
 import model.{Environment, InitializationError}
 
@@ -12,7 +12,7 @@ case class PaypalConfig(clientId: String, clientSecret: String, paypalMode: Payp
 
 object PaypalConfig {
 
-  implicit val paypalConfigParameterStoreLoadable: ParameterStoreLoadable[PaypalConfig] = new ParameterStoreLoadable[PaypalConfig] {
+  implicit val paypalConfigParameterStoreLoadable: ParameterStoreLoadableByEnvironment[PaypalConfig] = new ParameterStoreLoadableByEnvironment[PaypalConfig] {
 
     override def parametersByPathRequest(environment: Environment): GetParametersByPathRequest =
       new GetParametersByPathRequest()
@@ -22,7 +22,7 @@ object PaypalConfig {
 
     override def decode(environment: Environment, data: Map[String, String]): Validated[InitializationError, PaypalConfig] = {
 
-      val validator = new ParameterStoreValidator[PaypalConfig](environment, data); import validator._
+      val validator = new ParameterStoreValidator[PaypalConfig, Environment](environment, data); import validator._
       (
         validate("client-id"),
         validate("client-secret"),

--- a/src/main/scala/conf/PlayConfigEncoder.scala
+++ b/src/main/scala/conf/PlayConfigEncoder.scala
@@ -13,32 +13,31 @@ import scala.reflect.ClassTag
   def asPlayConfig(data: A): Configuration
 }
 
-object PlayConfigEncoder {
-
+class PlayConfigUpdater(val configLoader: ConfigLoader, val configuration: Configuration) {
   import PlayConfigEncoder.ops._
 
   // We need to load both configs here, since test/live mode can vary per request
-  def updateForRequestEnvironments[A : ClassTag : PlayConfigEncoder : ParameterStoreLoadableByEnvironment](
-      configLoader: ConfigLoader,
-      configuration: Configuration,
-      envs: RequestEnvironments): Configuration =
+  def update[A : ClassTag : PlayConfigEncoder : ParameterStoreLoadableByEnvironment](envs: RequestEnvironments): PlayConfigUpdater = {
 
-    (configLoader.configForEnvironment[A](envs.test), configLoader.configForEnvironment[A](envs.live))
-      .mapN((testConfig: A, liveConfig: A) =>
-        configuration ++ testConfig.asPlayConfig ++ liveConfig.asPlayConfig)
-      // Ok throwing an exception, since this method is called on the edge of the application
-      .valueOr(err => throw InitializationError("unable to update Play config", err))
+    val newConfiguration =
+      (configLoader.configForEnvironment[A](envs.test), configLoader.configForEnvironment[A](envs.live))
+        .mapN((testConfig: A, liveConfig: A) =>
+          configuration ++ testConfig.asPlayConfig ++ liveConfig.asPlayConfig)
+        // Ok throwing an exception, since this method is called on the edge of the application
+        .valueOr(err => throw InitializationError("unable to update Play config", err))
+
+    new PlayConfigUpdater(configLoader, newConfiguration)
+  }
 
   // We only need to load one config for that actual Play app mode,
   // because the app cannot change mode between requests
-  def updateForAppMode[A : ClassTag : PlayConfigEncoder : ParameterStoreLoadableByPlayAppMode](
-    configLoader: ConfigLoader,
-    configuration: Configuration,
-    mode: Mode
-  ): Configuration =
+  def update[A : ClassTag : PlayConfigEncoder : ParameterStoreLoadableByPlayAppMode](mode: Mode): PlayConfigUpdater = {
 
-    configLoader.configForPlayAppMode[A](mode)
+    val newConfiguration = configLoader.configForPlayAppMode[A](mode)
       .map(c => configuration ++ c.asPlayConfig)
       .valueOr(err => throw InitializationError("unable to update Play config", err))
+
+    new PlayConfigUpdater(configLoader, newConfiguration)
+  }
 
 }

--- a/src/main/scala/conf/PlayConfigEncoder.scala
+++ b/src/main/scala/conf/PlayConfigEncoder.scala
@@ -17,7 +17,7 @@ class PlayConfigUpdater(configLoader: ConfigLoader, val configuration: Configura
   import PlayConfigEncoder.ops._
 
   // We need to load both configs here, since test/live mode can vary per request
-  def update[A : ClassTag : PlayConfigEncoder : ParameterStoreLoadableByEnvironment](envs: RequestEnvironments): PlayConfigUpdater = {
+  def merge[A : ClassTag : PlayConfigEncoder : ParameterStoreLoadableByEnvironment](envs: RequestEnvironments): PlayConfigUpdater = {
 
     val newConfiguration =
       (configLoader.configForEnvironment[A](envs.test), configLoader.configForEnvironment[A](envs.live))
@@ -31,7 +31,7 @@ class PlayConfigUpdater(configLoader: ConfigLoader, val configuration: Configura
 
   // We only need to load one config for that actual Play app mode,
   // because the app cannot change mode between requests
-  def update[A : ClassTag : PlayConfigEncoder : ParameterStoreLoadableByPlayAppMode](mode: Mode): PlayConfigUpdater = {
+  def merge[A : ClassTag : PlayConfigEncoder : ParameterStoreLoadableByPlayAppMode](mode: Mode): PlayConfigUpdater = {
 
     val newConfiguration = configLoader.configForPlayAppMode[A](mode)
       .map(c => configuration ++ c.asPlayConfig)

--- a/src/main/scala/conf/PlayConfigEncoder.scala
+++ b/src/main/scala/conf/PlayConfigEncoder.scala
@@ -13,7 +13,7 @@ import scala.reflect.ClassTag
   def asPlayConfig(data: A): Configuration
 }
 
-class PlayConfigUpdater(val configLoader: ConfigLoader, val configuration: Configuration) {
+class PlayConfigUpdater(configLoader: ConfigLoader, val configuration: Configuration) {
   import PlayConfigEncoder.ops._
 
   // We need to load both configs here, since test/live mode can vary per request

--- a/src/main/scala/conf/PlayConfigEncoder.scala
+++ b/src/main/scala/conf/PlayConfigEncoder.scala
@@ -1,0 +1,41 @@
+package conf
+
+import model.{InitializationError, RequestEnvironments}
+import play.api.{Configuration, Mode}
+import simulacrum.typeclass
+import cats.syntax.apply._
+import ConfigLoader.{ParameterStoreLoadableByEnvironment, ParameterStoreLoadableByPlayAppMode}
+
+import scala.reflect.ClassTag
+
+
+@typeclass trait PlayConfigEncoder[A] {
+  def asPlayConfig(data: A): Configuration
+}
+
+object PlayConfigEncoder {
+
+  import PlayConfigEncoder.ops._
+
+  def updateForRequestEnvironments[A : ClassTag : PlayConfigEncoder : ParameterStoreLoadableByEnvironment](
+      configLoader: ConfigLoader,
+      configuration: Configuration,
+      envs: RequestEnvironments): Configuration =
+
+    (configLoader.configForEnvironment[A](envs.test), configLoader.configForEnvironment[A](envs.live))
+      .mapN((testConfig: A, liveConfig: A) =>
+        configuration ++ testConfig.asPlayConfig ++ liveConfig.asPlayConfig)
+      // Ok throwing an exception, since this method is called on the edge of the application
+      .valueOr(err => throw InitializationError("unable to update Play config", err))
+
+  def updateForAppMode[A : ClassTag : PlayConfigEncoder : ParameterStoreLoadableByPlayAppMode](
+    configLoader: ConfigLoader,
+    configuration: Configuration,
+    mode: Mode
+  ): Configuration =
+
+    configLoader.configForPlayAppMode[A](mode)
+      .map(c => configuration ++ c.asPlayConfig)
+      .valueOr(err => throw InitializationError("unable to update Play config", err))
+
+}

--- a/src/main/scala/conf/PlayConfigEncoder.scala
+++ b/src/main/scala/conf/PlayConfigEncoder.scala
@@ -17,6 +17,7 @@ object PlayConfigEncoder {
 
   import PlayConfigEncoder.ops._
 
+  // We need to load both configs here, since test/live mode can vary per request
   def updateForRequestEnvironments[A : ClassTag : PlayConfigEncoder : ParameterStoreLoadableByEnvironment](
       configLoader: ConfigLoader,
       configuration: Configuration,
@@ -28,6 +29,8 @@ object PlayConfigEncoder {
       // Ok throwing an exception, since this method is called on the edge of the application
       .valueOr(err => throw InitializationError("unable to update Play config", err))
 
+  // We only need to load one config for that actual Play app mode,
+  // because the app cannot change mode between requests
   def updateForAppMode[A : ClassTag : PlayConfigEncoder : ParameterStoreLoadableByPlayAppMode](
     configLoader: ConfigLoader,
     configuration: Configuration,

--- a/src/main/scala/conf/StripeConfig.scala
+++ b/src/main/scala/conf/StripeConfig.scala
@@ -3,8 +3,7 @@ package conf
 import cats.data.Validated
 import cats.syntax.apply._
 import com.amazonaws.services.simplesystemsmanagement.model.GetParametersByPathRequest
-
-import conf.ConfigLoader.{ParameterStoreLoadable, ParameterStoreValidator}
+import conf.ConfigLoader.{ParameterStoreLoadableByEnvironment, ParameterStoreValidator, environmentShow}
 import model.{Environment, InitializationError}
 
 sealed trait StripeAccountConfig {
@@ -23,7 +22,7 @@ case class StripeConfig(default: StripeAccountConfig.Default, au: StripeAccountC
 
 object StripeConfig {
 
-  implicit val stripeConfigParameterStoreLoadable: ParameterStoreLoadable[StripeConfig] = new ParameterStoreLoadable[StripeConfig] {
+  implicit val stripeConfigParameterStoreLoadable: ParameterStoreLoadableByEnvironment[StripeConfig] = new ParameterStoreLoadableByEnvironment[StripeConfig] {
 
     override def parametersByPathRequest(environment: Environment): GetParametersByPathRequest =
       new GetParametersByPathRequest()
@@ -32,7 +31,7 @@ object StripeConfig {
         .withRecursive(false)
 
     override def decode(environment: Environment, data: Map[String, String]): Validated[InitializationError, StripeConfig] = {
-      val validator = new ParameterStoreValidator[StripeConfig](environment, data); import validator._
+      val validator = new ParameterStoreValidator[StripeConfig, Environment](environment, data); import validator._
 
       val defaultAccount = (
         validate("default-public-key"),

--- a/src/main/scala/services/DatabaseProvider.scala
+++ b/src/main/scala/services/DatabaseProvider.scala
@@ -38,13 +38,5 @@ object DatabaseProvider {
       }
     }
 
-    // This should be used to override the Play configuration when injecting dependencies at compile time,
-    // and called before the first call to DatabaseProvider.loadDatabase()
-    // Otherwise, the dbApi val (which Play provides lazily) will be initialized without the sufficient config.
-    def updateConfiguration(configLoader: ConfigLoader, configuration: Configuration, envs: RequestEnvironments): Configuration =
-      (configLoader.configForEnvironment[DBConfig](envs.test), configLoader.configForEnvironment[DBConfig](envs.live))
-        .mapN((testConfig, liveConfig) => configuration ++ testConfig.asConfiguration ++ liveConfig.asConfiguration)
-        // Ok throwing an exception, since this method is called on the edge of the application
-        .valueOr(err => throw InitializationError("unable to update Play config with database settings", err))
   }
 }

--- a/src/main/scala/services/DatabaseProvider.scala
+++ b/src/main/scala/services/DatabaseProvider.scala
@@ -42,7 +42,7 @@ object DatabaseProvider {
     // and called before the first call to DatabaseProvider.loadDatabase()
     // Otherwise, the dbApi val (which Play provides lazily) will be initialized without the sufficient config.
     def updateConfiguration(configLoader: ConfigLoader, configuration: Configuration, envs: RequestEnvironments): Configuration =
-      (configLoader.loadConfig[DBConfig](envs.test), configLoader.loadConfig[DBConfig](envs.live))
+      (configLoader.configForEnvironment[DBConfig](envs.test), configLoader.configForEnvironment[DBConfig](envs.live))
         .mapN((testConfig, liveConfig) => configuration ++ testConfig.asConfiguration ++ liveConfig.asConfiguration)
         // Ok throwing an exception, since this method is called on the edge of the application
         .valueOr(err => throw InitializationError("unable to update Play config with database settings", err))


### PR DESCRIPTION
Since we don't want the Play app secret in version control, we should load it from the parameter store.

This adds some complication because unlike most of our config, it varies depending on the Play app mode, not the request environment.

## Potential improvements
- Parameterise `ParameterStoreLoadable` on the environment type so we don't need the verbosity of two separate type classes. (This requires use of this: https://github.com/non/kind-projector)