### PR TITLE
Reverse order of identity creation and making the charge

### DIFF
--- a/src/main/scala/backend/PaypalBackend.scala
+++ b/src/main/scala/backend/PaypalBackend.scala
@@ -3,12 +3,15 @@ package backend
 import backend.PaypalBackend.PaypalBackendError
 import cats.data.EitherT
 import com.paypal.api.payments.Payment
+import conf.{ConfigLoader, IdentityConfig, OphanConfig, PaypalConfig}
 import model.db.ContributionData
 import model.paypal.{CapturePaypalPaymentData, CreatePaypalPaymentData, ExecutePaypalPaymentData, PaypalApiError}
 import model._
 import services._
 import util.EnvironmentBasedBuilder
 import cats.implicits._
+import cats.kernel.Semigroup
+import com.gu.acquisition.model.errors.OphanServiceError
 import com.typesafe.scalalogging.StrictLogging
 import model.acquisition.PaypalAcquisition
 import play.api.libs.ws.WSClient
@@ -19,35 +22,52 @@ import conf._
 class PaypalBackend(paypalService: PaypalService, databaseService: DatabaseService,
   identityService: IdentityService, ophanService: OphanService, emailService: EmailService) extends StrictLogging {
 
+  def combineResults(
+    result1: EitherT[Future, PaypalBackendError, Unit],
+    result2:  EitherT[Future, PaypalBackendError, Unit])(implicit pool: DefaultThreadPool):  EitherT[Future, PaypalBackendError, Unit] = {
+      EitherT(for {
+        r1 <- result1.toValidated
+        r2 <- result2.toValidated
+      } yield {
+        r1.combine(r2).toEither
+      })
+  }
 
   // Convert the result of the identity id operation,
   // into the monad used by the for comprehension in the createCharge() method.
   def getOrCreateIdentityIdFromEmail(email: String)(implicit pool: DefaultThreadPool): EitherT[Future, PaypalBackendError, Long] =
     identityService.getOrCreateIdentityIdFromEmail(email).leftMap(PaypalBackendError.fromIdentityError)
 
-  def insetContributionDataToPostgres(contributionData: ContributionData)(implicit pool: DefaultThreadPool): EitherT[Future, PaypalBackendError, Unit] = {
+  def insertContributionDataToPostgres(contributionData: ContributionData)(implicit pool: DefaultThreadPool): EitherT[Future, PaypalBackendError, Unit] = {
     databaseService.insertContributionData(contributionData).leftMap(PaypalBackendError.fromDatabaseError)
   }
 
+  def submitAcquisitionToOphan(payment: Payment, acquisitionData: AcquisitionData)(implicit pool: DefaultThreadPool): EitherT[Future, PaypalBackendError, Unit] = {
+    ophanService.submitAcquisition(PaypalAcquisition(payment, acquisitionData)).bimap(PaypalBackendError.fromOphanError, _ => ())
+  }
 
 
   def trackContribution(payment: Payment, acquisitionData: AcquisitionData)(implicit pool: DefaultThreadPool): EitherT[Future, PaypalBackendError, Unit]  = {
     getOrCreateIdentityIdFromEmail(payment.getPotentialPayerInfo.getEmail).map(Option(_))
       .recover {
-        case err => {
-          logger.error(err.getMessage)
+        case err =>
+          logger.error("Error getting identityId", err)
           None
-        }
       }
-      .map { identityId =>
+      .flatMap { identityId =>
         ContributionData.fromPaypalCharge(identityId, payment)
-          .map {
-            contributionData => {
-              insetContributionDataToPostgres(contributionData)
-              //leaving this here for now until we add identityId to the acquisition thrift model
-              ophanService.submitAcquisition(PaypalAcquisition(payment, acquisitionData))
-            }
-          }
+          .leftMap(_ => PaypalBackendError.fromDatabaseError(null))
+          .toEitherT[Future]
+      }
+      .flatMap { contributionData =>
+        combineResults(
+          submitAcquisitionToOphan(payment, acquisitionData),
+          insertContributionDataToPostgres(contributionData)
+        )
+      }
+      .leftMap { err =>
+        logger.error("Error tracking contribution", err)
+        err
       }
   }
 
@@ -120,15 +140,22 @@ object PaypalBackend {
     override def getMessage: String = this match {
       case PaypalBackendError.Database(err) => err.getMessage
       case PaypalBackendError.Service(err) => err.getMessage
+      case PaypalBackendError.Ophan(err) => err.getMessage
+      case PaypalBackendError.MultipleErrors(errors) => errors.map(_.getMessage).mkString("&")
     }
   }
 
   object PaypalBackendError {
     final case class Database(error: DatabaseService.Error) extends PaypalBackendError
     final case class Service(error: IdentityClient.Error) extends PaypalBackendError
+    final case class Ophan(error: OphanServiceError) extends PaypalBackendError
+    final case class MultipleErrors(errors: List[PaypalBackendError]) extends PaypalBackendError
+
+    implicit val payPalBackendSemiGroup: Semigroup[PaypalBackendError] = Semigroup.instance((x,y) => MultipleErrors(List(x,y)))
 
     def fromIdentityError(err: IdentityClient.Error): PaypalBackendError = Service(err)
     def fromDatabaseError(err: DatabaseService.Error): PaypalBackendError= Database(err)
+    def fromOphanError(err: OphanServiceError): PaypalBackendError= Ophan(err)
   }
 }
 

--- a/src/main/scala/backend/StripeBackend.scala
+++ b/src/main/scala/backend/StripeBackend.scala
@@ -7,7 +7,7 @@ import com.stripe.model.Charge
 import com.typesafe.scalalogging.StrictLogging
 import play.api.libs.ws.WSClient
 import util.EnvironmentBasedBuilder
-import cats.instances.future.catsStdInstancesForFuture
+import cats.instances.future._
 import scala.concurrent.Future
 import conf.{ConfigLoader, IdentityConfig, StripeConfig}
 import model._
@@ -24,25 +24,23 @@ class StripeBackend(stripeService: StripeService, databaseService: DatabaseServi
   def getOrCreateIdentityIdFromEmail(email: String)(implicit pool: DefaultThreadPool): EitherT[Future, StripeBackendError, Long] =
     identityService.getOrCreateIdentityIdFromEmail(email).leftMap(StripeBackendError.fromIdentityError)
 
-
-  def insetContributionData(contributionData: ContributionData)(implicit pool: DefaultThreadPool): EitherT[Future, StripeBackendError, Unit] = {
+  def insertContributionData(contributionData: ContributionData)(implicit pool: DefaultThreadPool): EitherT[Future, StripeBackendError, Unit] = {
     databaseService.insertContributionData(contributionData).leftMap(StripeBackendError.fromDatabaseError)
   }
 
   def trackContribution(charge: Charge, data: StripeChargeData)(implicit pool: DefaultThreadPool): EitherT[Future, StripeBackendError, Unit]  = {
     getOrCreateIdentityIdFromEmail(data.identityData.email).map(Option(_))
       .recover {
-        case err => {
-          logger.error(err.getMessage)
+        case err =>
+          logger.error("Error getting Identity Id", err)
           None
-        }
       }
       .flatMap { identityId =>
-        val contributionData = ContributionData.fromStripeCharge(identityId, charge)
-        insetContributionData(contributionData)
+        insertContributionData(
+          ContributionData.fromStripeCharge(identityId, charge)
+        )
       }
   }
-
 
   // TODO: send acquisition event
   // Ok using the default thread pool - the mapping function is not computationally intensive, nor does is perform IO.

--- a/src/main/scala/backend/StripeBackend.scala
+++ b/src/main/scala/backend/StripeBackend.scala
@@ -1,13 +1,13 @@
 package backend
 
+import backend.StripeBackend.StripeBackendError
 import cats.data.EitherT
-import cats.instances.future._
 import cats.syntax.apply._
 import com.stripe.model.Charge
 import com.typesafe.scalalogging.StrictLogging
 import play.api.libs.ws.WSClient
 import util.EnvironmentBasedBuilder
-
+import cats.instances.future.catsStdInstancesForFuture
 import scala.concurrent.Future
 import conf.{ConfigLoader, IdentityConfig, StripeConfig}
 import model._
@@ -21,10 +21,15 @@ class StripeBackend(stripeService: StripeService, databaseService: DatabaseServi
 
   // Convert the result of the identity id operation,
   // into the monad used by the for comprehension in the createCharge() method.
-  def getOrCreateIdentityIdFromEmail(email: String)(implicit pool: DefaultThreadPool): EitherT[Future, StripeChargeError, Long] =
-    identityService.getOrCreateIdentityIdFromEmail(email).leftMap(err => StripeChargeError.fromThrowable(err))
+  def getOrCreateIdentityIdFromEmail(email: String)(implicit pool: DefaultThreadPool): EitherT[Future, StripeBackendError, Long] =
+    identityService.getOrCreateIdentityIdFromEmail(email).leftMap(StripeBackendError.fromIdentityError)
 
-  def trackContribution(charge: Charge, data: StripeChargeData)(implicit pool: DefaultThreadPool): EitherT[Future, StripeChargeError, Future[Unit]]  = {
+
+  def insetContributionData(contributionData: ContributionData)(implicit pool: DefaultThreadPool): EitherT[Future, StripeBackendError, Unit] = {
+    databaseService.insertContributionData(contributionData).leftMap(StripeBackendError.fromDatabaseError)
+  }
+
+  def trackContribution(charge: Charge, data: StripeChargeData)(implicit pool: DefaultThreadPool): EitherT[Future, StripeBackendError, Unit]  = {
     getOrCreateIdentityIdFromEmail(data.identityData.email).map(Option(_))
       .recover {
         case err => {
@@ -32,9 +37,9 @@ class StripeBackend(stripeService: StripeService, databaseService: DatabaseServi
           None
         }
       }
-      .map { identityId =>
+      .flatMap { identityId =>
         val contributionData = ContributionData.fromStripeCharge(identityId, charge)
-        databaseService.insertContributionData(contributionData)
+        insetContributionData(contributionData)
       }
   }
 
@@ -45,12 +50,8 @@ class StripeBackend(stripeService: StripeService, databaseService: DatabaseServi
     for {
       charge <- stripeService.createCharge(data)
       _ = trackContribution(charge, data)
-    } yield {
-      // Don't use flat map for inserting the contribution data -
-      // the result the client receives as to whether the charge is successful,
-      // should not be dependent on this operation.
-      StripeChargeSuccess.fromCharge(charge)
-    }
+    } yield StripeChargeSuccess.fromCharge(charge)
+
 }
 
 object StripeBackend {
@@ -77,5 +78,21 @@ object StripeBackend {
         .map(IdentityService.fromIdentityConfig): InitializationResult[IdentityService]
     ).mapN(StripeBackend.apply)
   }
+
+  sealed abstract class StripeBackendError extends Exception {
+    override def getMessage: String = this match {
+      case StripeBackendError.Database(err) => err.getMessage
+      case StripeBackendError.Service(err) => err.getMessage
+    }
+  }
+
+  object StripeBackendError {
+    final case class Database(error: DatabaseService.Error) extends StripeBackendError
+    final case class Service(error: IdentityClient.Error) extends StripeBackendError
+
+    def fromIdentityError(err: IdentityClient.Error): StripeBackendError = Service(err)
+    def fromDatabaseError(err: DatabaseService.Error): StripeBackendError = Database(err)
+  }
+
 }
 

--- a/src/main/scala/model/stripe/StripeChargeSuccess.scala
+++ b/src/main/scala/model/stripe/StripeChargeSuccess.scala
@@ -1,13 +1,11 @@
 package model.stripe
 
+import com.stripe.model.Charge
 import io.circe.generic.JsonCodec
 
-import model.Currency
-import model.db.ContributionData
-
-@JsonCodec case class StripeChargeSuccess private (currency: Currency, amount: Long)
+@JsonCodec case class StripeChargeSuccess private (currency: String, amount: Long)
 
 object StripeChargeSuccess {
-  def fromContributionData(data: ContributionData): StripeChargeSuccess =
-    StripeChargeSuccess(data.currency, data.amount)
+  def fromCharge(charge: Charge): StripeChargeSuccess =
+    StripeChargeSuccess(charge.getCurrency, charge.getAmount)
 }

--- a/src/main/scala/services/DatabaseService.scala
+++ b/src/main/scala/services/DatabaseService.scala
@@ -33,9 +33,7 @@ class PostgresDatabaseService private (database: Database)(implicit pool: JdbcTh
     Future(database.withConnection { implicit conn => insertStatement.execute() })
       .attemptT
       .bimap(
-        err => {
-          DatabaseService.Error("unable to insert contribution into database", Some(err))
-        },
+        err => DatabaseService.Error("unable to insert contribution into database", Some(err)),
         _ => logger.info("contribution inserted into database")
       )
 

--- a/src/main/scala/services/DatabaseService.scala
+++ b/src/main/scala/services/DatabaseService.scala
@@ -1,13 +1,13 @@
 package services
 
 import anorm._
+import cats.data.EitherT
 import cats.syntax.applicativeError._
 import cats.instances.future._
 import com.typesafe.scalalogging.StrictLogging
 import play.api.db.Database
 
 import scala.concurrent.Future
-
 import model.JdbcThreadPool
 import model.db.ContributionData
 
@@ -17,21 +17,29 @@ trait DatabaseService {
   // the return type is not modelled as an EitherT,
   // since the result of the insert has no dependencies.
   // See e.g. backend.StripeBackend for more context.
-  def insertContributionData(data: ContributionData): Future[Unit]
+  def insertContributionData(data: ContributionData): EitherT[Future, DatabaseService.Error, Unit]
+}
+
+object DatabaseService {
+  case class Error(message: String, err: Option[Throwable]) extends Exception {
+    override def getMessage: String = err.fold(message)(error => s"$message - ${error.getMessage}")
+  }
 }
 
 class PostgresDatabaseService private (database: Database)(implicit pool: JdbcThreadPool)
   extends DatabaseService with StrictLogging {
 
-  private def executeTransaction(insertStatement: SimpleSql[Row]): Future[Unit] =
+  private def executeTransaction(insertStatement: SimpleSql[Row]): EitherT[Future, DatabaseService.Error, Unit] =
     Future(database.withConnection { implicit conn => insertStatement.execute() })
       .attemptT
-      .fold(
-        err => logger.error("unable to insert contribution into database", err),
+      .bimap(
+        err => {
+          DatabaseService.Error("unable to insert contribution into database", Some(err))
+        },
         _ => logger.info("contribution inserted into database")
       )
 
-  override def insertContributionData(data: ContributionData): Future[Unit] = {
+  override def insertContributionData(data: ContributionData): EitherT[Future, DatabaseService.Error, Unit] = {
 
     val transaction = SQL"""
       BEGIN;
@@ -87,7 +95,7 @@ class PostgresDatabaseService private (database: Database)(implicit pool: JdbcTh
 }
 
 object PostgresDatabaseService {
-
   def fromDatabase(database: Database)(implicit pool: JdbcThreadPool): PostgresDatabaseService =
     new PostgresDatabaseService(database)
 }
+


### PR DESCRIPTION
This PR reverses the order of the creation of `identityId` and making the charge. By doing it this way, we are not dependent on the identity API giving us a successful result to make a charge.

If we do fail to get the `identityId`, we log an error and carry on, still populating the postgres database with the information about the charge, _sans_ `identityId`

