### PR TITLE
Encrypt AMI

### DIFF
--- a/src/main/resources/riff-raff.yaml
+++ b/src/main/resources/riff-raff.yaml
@@ -8,6 +8,7 @@ deployments:
       amiTags:
         Recipe: xenial-membership
         AmigoStage: PROD
+      amiEncrypted: true
       templatePath: cloud-formation.yaml
   payment-api:
     type: autoscaling


### PR DESCRIPTION
For GDPR security reasons, we want to use encrypted AMIs

https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIEncryption.html